### PR TITLE
Celery4 compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     tests_require=[
-        'django<=2',
+        'django<2',
         'mock>=2.0.0',
         'pytest>=2.9.0',
         'celery',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     tests_require=[
-        'django>=1.4.3',
+        'django<=2',
         'mock>=2.0.0',
         'pytest>=2.9.0',
         'celery',

--- a/src/pylogctx/celery.py
+++ b/src/pylogctx/celery.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import logging
 
-from celery.app import current_task
+from celery import current_task
 from celery.app.task import Task
 
 from .core import context
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class LoggingTask(Task):
     def __call__(self, *args, **kwargs):
-        task = current_task()
+        task = current_task
 
         try:
             context.update(task)

--- a/src/pylogctx/core.py
+++ b/src/pylogctx/core.py
@@ -129,7 +129,7 @@ def log_adapter(class_):
 
 
 def adapt(object_):
-    for class_ in type(object_).__mro__:
+    for class_ in object_.__class__.__mro__:
         try:
             adapter = _adapter_mapping[class_]
             break

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -2,11 +2,14 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 from mock import patch, call
 
+
 from pylogctx.django import (
     ExtractRequestContextMiddleware,
     OuterMiddleware,
     context as log_context
 )
+
+
 from pylogctx import log_adapter
 
 


### PR DESCRIPTION
Some fixes to add celevy v4 compatibilty.

Tested with the following configuration : 

- python2.7 and python3.5
- celery versions : **3.1.19**, **3.1.15**, **4.0** and **4.1**