### PR TITLE
Add warning log when deep copy django model object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,13 @@
 ===========
 
 
-1.6 (2018(01-03)
+1.7 (unreleased)
+++++++++++++++++
+
+- Add warning log when deep copy django model object
+
+
+1.6 (2018-01-03)
 ++++++++++++++++
 
 - Fix update context from celery loggingTask

--- a/src/pylogctx/helpers.py
+++ b/src/pylogctx/helpers.py
@@ -1,4 +1,21 @@
+from __future__ import absolute_import
+
 import copy
+import logging
+
+from django.db import models
+
+logger = logging.getLogger(__name__)
+
+
+def prevent_django_model(value):
+
+    # Detect value is an instance from django model to warn before a deepcopy.
+    # Indeed when an django model object is "deepcopied",
+    # all these relationships are fetched.
+    if isinstance(value, models.Model):
+        logger.warning("[Pylogctx] Be careful an django model object: %s is "
+                       "deepcopying", value)
 
 
 def deepupdate(target, src):
@@ -24,4 +41,5 @@ def deepupdate(target, src):
                 elif isinstance(v, set):
                     target[k].update(v)
             else:
+                prevent_django_model(v)
                 target[k] = copy.deepcopy(v)


### PR DESCRIPTION
Je n'ai pas créer de test pour ce changement, un peu chiant avec les models django.

@bersace ça te parait pertinent comme PR ? on a un le soucis de notre côté, des req à tout va sur une erreur d'ajout d'object model django dans le context !  on s'en est rendu compte grâce à un test assert num query, heureusement... 

ça mange pas de pain un petit warning ? 