### PR TITLE
Add release helper for co-maintainership

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -17,4 +17,4 @@ Here are steps to release:
 - Ensure the new version has an entry in CHANGELOG_.
 - Increment version in ``setup.py``.
 - Run ``make release`` to create commit and tag.
-- Now run ``make upload`` to create tarball and wheel. You
+- Now run ``make upload`` to create tarball and wheel.

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,0 +1,20 @@
+#####################
+ Hacking on pylogctx
+#####################
+
+
+Releasing a new version
+=======================
+
+The root ``Makefile`` ease releasing and uploading a new version of pylogctx.
+Here is the release checklist:
+
+- You must have write access to ``master`` on upstream repository.
+- You must have upload access to https://pypi.python.org/pypi/pylogctx.
+
+Here are steps to release:
+
+- Ensure the new version has an entry in CHANGELOG_.
+- Increment version in ``setup.py``.
+- Run ``make release`` to create commit and tag.
+- Now run ``make upload`` to create tarball and wheel. You

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+VERSION=$(python setup.py --version)
+UPSTREAM=git@github.com:peopledoc/pylogctx.git
+
+default:
+
+release:
+	python setup.py egg_info
+	: Ensure Changelog entry
+	grep -q $(VERSION) CHANGELOG.rst
+	: Pin date of release
+	sed -i '/$(VERSION)/s/unreleased/$(date +%Y-%m-%d)/' CHANGELOG.rst
+	: Commit, tag and push setup.py and Changelog
+	git commit setup.py CHANGELOG.rst -m "Version $(VERSION)"
+	git tag $(VERSION)
+	git push $(UPSTREAM)
+	git push $(UPSTREAM)
+	@echo Now upload with make upload
+
+upload:
+	: Ensure we build from tag
+	git describe --exact-match --tags
+	python3 setup.py sdist bdist_wheel --universal upload -r pypi

--- a/README.rst
+++ b/README.rst
@@ -83,11 +83,11 @@ There is a few helpers for Celery_ and Django_ projects. See USAGE_ for details!
 Contributors
 ============
 
-Do you want py3 support or other nice improvements ? Join us to make log
-rocking better!
+Join us to make log rocking better! Read HACKING_ and ask maintainers:
 
-* Lev Orekhov `@lorehov <https://github.com/lorehov>`_
+* David STEINBERGER `@dsteinberger <https://github.com/dsteinberger>`_
 * Étienne BERSAC `@bersace <https://github.com/bersace>`_
+* Lev Orekhov `@lorehov <https://github.com/lorehov>`_
 
 
 .. |BSD| image:: https://img.shields.io/pypi/l/pylogctx.svg?maxAge=2592000
@@ -108,4 +108,5 @@ rocking better!
 
 .. _Celery: http://www.celeryproject.org/
 .. _Django: https://www.djangoproject.com/
+.. _HACKING: https://github.com/novafloss/pylogctx/blob/master/HACKING.rst
 .. _USAGE: https://github.com/novafloss/pylogctx/blob/master/USAGE.rst


### PR DESCRIPTION
@lorehov : @dsteinberger from PeopleDoc is joining maintainership. Here is a helper to streamline releases of pylogctx.

That's not easy to test. I suggest me to do the next release to check this and @dsteinberger do the following one.
