### PR TITLE
Fix nested LazyAccessor object when deepupdate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
  Changelog
 ===========
 
+
+1.10 (unreleased)
++++++++++++++++++
+
+- Fix nested LazyAccessor object when deepupdate
+
+
 1.10 (2018-03-12)
 +++++++++++++++++
 

--- a/src/pylogctx/helpers.py
+++ b/src/pylogctx/helpers.py
@@ -14,6 +14,7 @@ def deepupdate(target, src):
     >>> print t
     {'name': 'toto', 'hobbies': ['programming', 'chess', 'gaming']}
     """
+    from pylogctx.core import LazyAccessor
     if src and isinstance(src, dict):
         for k, v in src.items():
             if k in target and target[k] is not None and isinstance(
@@ -25,10 +26,13 @@ def deepupdate(target, src):
                 elif isinstance(v, set):
                     target[k].update(v)
             else:
-                from pylogctx.core import LazyAccessor
                 if isinstance(v, LazyAccessor):
                     # To have a lazy representation from the instance we need
                     # to keep the reference
                     target[k] = v
+                elif isinstance(v, dict):
+                    # For manage nested LazyAccessor object
+                    target[k] = {}
+                    deepupdate(target[k], v)
                 else:
                     target[k] = copy.deepcopy(v)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -112,6 +112,7 @@ def test_deep_update_dict(context):
     # Override value `tata1/titi1`
     log_context.update(myField={'toto': {'tata1': {'titi1': 'val'}}})
     fields = log_context.as_dict()
+
     assert fields == {
         'myField': {'toto': {'tata1': {'titi1': 'val',
                                        'titi2': 'tutu'}}}}
@@ -316,6 +317,33 @@ def test_lazy_accessor_deepupdate(context):
 
     fields = log_context.as_dict()
     assert str(fields['lazy_instance']) == 'bar'
+
+
+def test_lazy_accessor_deepupdate_nested(context):
+    log_context.remove('rid')
+
+    from pylogctx import LazyAccessor
+
+    class MyObject(object):
+        value = 'foo'
+
+        def __repr__(self):
+            return 'foo'
+
+    instance = MyObject()
+    lazy_instance = LazyAccessor(instance, 'value')
+
+    log_context.update(parent={"lazy_instance": lazy_instance,
+                               "foo": "bar"})
+
+    fields = log_context.as_dict()
+    assert str(fields['parent']['lazy_instance']) == 'foo'
+
+    # Check value change for LazyAccessor
+    instance.value = 'bar'
+
+    fields = log_context.as_dict()
+    assert str(fields['parent']['lazy_instance']) == 'bar'
 
 
 def test_filter_exc_info(record):


### PR DESCRIPTION
@bersace un autre bug, je l'ai vu sur mon app, car bcp bcp de lazyAcessor et je passe de 30s pour un test à 19s donc pas négligable, mais reste bcp moins que la première optim la dessus qui faisait passer de 102s à 30s :) 