### PR TITLE
Fix #39 Remove DeprecationWarning

### DIFF
--- a/src/pylogctx/celery.py
+++ b/src/pylogctx/celery.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
 import logging
-import inspect
 import warnings
 
 from celery import current_task
 from celery import Task
 
+from .compat import getargspec
 from .core import context
 
 
@@ -29,8 +29,8 @@ class LoggingTask(Task):
         self.save_context = context.as_dict()
         context.clear()
 
-        args_repr = inspect.getargspec(self.before_call)
-        if args_repr.varargs is None:
+        arg_spec = getargspec(self.before_call)
+        if arg_spec.varargs is None:
             # To keep breaking compat
             warnings.warn('Method `before_call` without args is deprecated')
             self.before_call()
@@ -47,8 +47,8 @@ class LoggingTask(Task):
         try:
             return super(LoggingTask, self).__call__(*args, **kwargs)
         finally:
-            args_repr = inspect.getargspec(self.after_call)
-            if args_repr.varargs is None:
+            arg_spec = getargspec(self.after_call)
+            if arg_spec.varargs is None:
                 # To keep breaking compat
                 warnings.warn('Method `after_call` without args is deprecated')
                 self.after_call()

--- a/src/pylogctx/compat.py
+++ b/src/pylogctx/compat.py
@@ -1,0 +1,10 @@
+import inspect
+
+
+def getargspec(callable):
+    try:
+        # Python 3
+        return inspect.getfullargspec(callable)
+    except AttributeError:
+        # Python 2
+        return inspect.getargspec(callable)


### PR DESCRIPTION
Remove deprecationwarning.
DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()

Fix #39