### PR TITLE
Add support for prefixes on log context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,23 @@ matrix:
     - python: 3.6
       env: TOX_ENV=py36-django20
 
+    - python: 3.7
+      env: TOX_ENV=py37-django111
+
+    - python: 3.7
+      env: TOX_ENV=py37-django20
+
+    - python: 3.7
+      env: TOX_ENV=py37-django22
+
+    - python: 3.8
+      env: TOX_ENV=py38-django111
+
+    - python: 3.8
+      env: TOX_ENV=py38-django20
+
+    - python: 3.8
+      env: TOX_ENV=py38-django22
+
     - python: 2.7
       env: TOX_ENV=lint

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/src/pylogctx/core.py
+++ b/src/pylogctx/core.py
@@ -100,33 +100,40 @@ class Context(threading.local):
         return itertools.chain(*[self.as_dict().items()])
 
     def prefix(self, prefix, separator="__", ):
-        """Add a prefix to the log context for the scope of a method call / class.
+        """Add a prefix to the log context for the scope of a method call /
+        class.
 
         NOTE: There's a high chance this is only Python 3+ compatible.
         """
         def _prefix(func):
             @wraps(func)
             def wrapper(*args, **kwargs):
-                # Fairly loose checks on whether or not we can chuck these into log
-                # context. But, if they can be cast to a string, let's do it.
+                # Fairly loose checks on whether or not we can chuck these into
+                # log context. But, if they can be cast to a string, let's do
+                # it.
                 try:
                     str(prefix)
                 except Exception:
-                    raise ValueError("Cannot cast prefix to string: %r" % type(prefix))
+                    raise ValueError(
+                        "Cannot cast prefix to string: %r" % type(prefix)
+                    )
 
                 try:
                     str(separator)
                 except Exception:
-                    raise ValueError("Cannot cast separator to string: %r" % type(separator))
+                    raise ValueError(
+                        "Cannot cast separator to string: %r" % type(separator)
+                    )
 
                 old_update = self.update
+
                 def prefix_update(**updates):
                     old_update(
                         **{
                             "{}{}{}".format(prefix, separator, k): v
                             for k, v in updates.items()
                         }
-                )
+                    )
 
                 self.update = prefix_update
                 try:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,2 @@
+# Dummy settings for django tests
+SECRET_KEY = 'deadbeef'

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = lint,py27-django111,py{35,36}-django{111,20}
+envlist = lint,py27-django111,py{35,36,37,38}-django{111,20}
 
 [testenv]
 basepython =
     py27: python2.7
     py35: python3.5
     py36: python3.6
+    py37: python3.7
+    py38: python3.8
 commands = python setup.py test
 deps =
     django111: Django>=1.11,<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py27-django111,py{35,36,37,38}-django{111,20}
+envlist = lint,py27-django111,py{35,36,37,38}-django{111,20},py{37,38}-django22
 
 [testenv]
 basepython =
@@ -12,6 +12,7 @@ commands = python setup.py test
 deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django22: Django>=2.2,<3.0
 
 [testenv:lint]
 basepython = python2.7


### PR DESCRIPTION
This PR adds simple support for a prefix decorator. If it's useful I'll update usage with a code example. The idea is pretty straight forward:
```python
from pylogctx import context as log_context

@log_context.prefix("my_method_call")
def my_method():
    log_context.update(foo="bar")
```
Which will add the prefix `my_method_call__` to any context updates. We use a pattern similar to this internally to help build out rich context when a human is inspecting log messages. I also went ahead and updated tox + travis + setup.py to use Django 2.2 (which is on LTS) as well as Python 3.7 and 3.8 (as well as just generally fixing tests that were broken)